### PR TITLE
Support nested skill directories

### DIFF
--- a/ucagent/stage/vmanager.py
+++ b/ucagent/stage/vmanager.py
@@ -655,7 +655,7 @@ class StageManager(object):
         skills_to_use = [skill_name for skill_name in cstage.skill_list]
         if skills_to_use:
             if self.agent.cfg.skill.use_skill:
-                formatted_skill_list = list_skills_in_format(_list_skills(self.workspace+"/.ucagent/skills"), self.workspace, skills_to_use)
+                formatted_skill_list = list_skills_in_format(_list_skills(self.workspace), self.workspace, skills_to_use)
                 tips["notes"] = tips.get("notes", "") + f"Firstly you must read the SKILL.md of the following skills to know how to complete current stage:\n{formatted_skill_list}\n"
             else:
                 raise ValueError("Enable the arg(--use-skill) to use skills, or remove the skill_list specified in current stage.")
@@ -745,16 +745,11 @@ class StageManager(object):
         """set the skill usage of curretn stage or return feedback based on skill_usage"""
         current_stage = self.get_current_stage()
         if current_stage.skill_list:
-            skills_dir = os.path.join(self.workspace, ".ucagent/skills")
-            have_skill_list = []
-            if os.path.isdir(skills_dir):
-                have_skill_list = sorted(
-                    name for name in os.listdir(skills_dir)
-                    if os.path.isdir(os.path.join(skills_dir, name))
-                )
             for skill_name in current_stage.skill_list:
-                if skill_name not in have_skill_list:
-                    raise ValueError(f"Skill '{skill_name}' is not found in workspace path '{skills_dir}'. ")
+                skill_root = fc.get_workspace_skill_root(self.workspace)
+                skill_dir = fc.find_skill_dir_by_name(skill_root, skill_name)
+                if not skill_dir:
+                    raise ValueError(f"Skill '{skill_name}' is not found in workspace. ")
                 if skill_name not in skill_usage:
                     return f"You must use skill '{skill_name}' in current stage, using tool `ListSkill` to list and use it."
                 else:

--- a/ucagent/stage/vstage.py
+++ b/ucagent/stage/vstage.py
@@ -205,14 +205,6 @@ class VerifyStage(object):
         except Exception as e:
             return {"error": f"cannot get file content ({file_path}) from commit ({hash_id}): {e}"}
 
-    def get_skill_root(self):
-        return fc.get_abs_path_cwd_ucagent(self.workspace, "skills")
-
-    def is_skill_path(self, file_path):
-        skill_root = self.get_skill_root()
-        abs_file_path = os.path.abspath(self.workspace + os.path.sep + file_path)
-        return abs_file_path.startswith(skill_root)
-
     def on_init(self):
         for c in self.checker:
             c.on_init()
@@ -230,9 +222,9 @@ class VerifyStage(object):
                     return hook_func(original_method, *args, **kwargs)
                 setattr(self, method_name, hooked_method)
             self.add_hook = add_hook
-            skills_dir = self.get_skill_root()
+            skills_dir = fc.get_workspace_skill_root(self.workspace)
             for skill_name in self.skill_list.keys():
-                script_dir = os.path.join(skills_dir, skill_name, "scripts")
+                script_dir = os.path.join(fc.find_skill_dir_by_name(skills_dir, skill_name) or os.path.join(skills_dir, skill_name), "scripts")
                 init_file = os.path.join(script_dir, "__init__.py")
                 if os.path.isdir(script_dir) and os.path.isfile(init_file) and os.path.getsize(init_file) > 0:
                     try:
@@ -337,6 +329,11 @@ class VerifyStage(object):
             c.set_stage_manager(manager)
         self.vmanager = manager
 
+    def is_skill_path(self, file_path):
+        skill_root = fc.get_workspace_skill_root(self.workspace)
+        abs_file_path = os.path.abspath(self.workspace + os.path.sep + file_path)
+        return abs_file_path.startswith(skill_root)
+    
     def on_file_read(self, success, file_path, content):
         if not self.is_curent_active():
             return
@@ -350,11 +347,11 @@ class VerifyStage(object):
 
         if self.is_skill_path(file_path):
             abs_path = os.path.abspath(self.workspace + os.path.sep + file_path)
-            abs_skill_root = self.get_skill_root()
-            skill_name = os.path.relpath(abs_path, abs_skill_root).split(os.path.sep)[0]
-            if skill_name in self.skill_list:
-                self.set_usage_skill_list(skill_name, read=True)
-                info(f"[{self.__class__.__name__}.{self.name}] Skill {skill_name} has been read by the LLM.")
+            if os.path.basename(abs_path) == "SKILL.md":
+                skill_name = os.path.basename(os.path.dirname(abs_path))
+                if skill_name in self.skill_list:
+                    self.set_usage_skill_list(skill_name, read=True)
+                    info(f"[{self.__class__.__name__}.{self.name}] Skill {skill_name} has been read by the LLM.")
 
     def __repr__(self):
         return f"VerifyStage(name={self.name}, description={self.description()}, "+\

--- a/ucagent/stage/vstage.py
+++ b/ucagent/stage/vstage.py
@@ -224,7 +224,7 @@ class VerifyStage(object):
             self.add_hook = add_hook
             skills_dir = fc.get_workspace_skill_root(self.workspace)
             for skill_name in self.skill_list.keys():
-                script_dir = os.path.join(fc.find_skill_dir_by_name(skills_dir, skill_name) or os.path.join(skills_dir, skill_name), "scripts")
+                script_dir = os.path.join(fc.find_skill_dir_by_name(skills_dir, skill_name), "scripts")
                 init_file = os.path.join(script_dir, "__init__.py")
                 if os.path.isdir(script_dir) and os.path.isfile(init_file) and os.path.getsize(init_file) > 0:
                     try:

--- a/ucagent/tools/skill.py
+++ b/ucagent/tools/skill.py
@@ -5,7 +5,6 @@ This module provides tools to list and manage available skills in the workspace.
 
 import re
 import os
-import shutil
 from pathlib import Path
 from typing import Optional, TypedDict, Any, List
 import yaml
@@ -14,6 +13,7 @@ from pydantic import Field, BaseModel
 import subprocess
 from .uctool import UCTool, ArgsSchema, EmptyArgs
 from ucagent.util.log import warning,info
+import ucagent.util.functions as fc
 
 # Security: Maximum size for SKILL.md files to prevent DoS attacks (10MB)
 MAX_SKILL_FILE_SIZE = 10 * 1024 * 1024
@@ -154,26 +154,29 @@ def _parse_skill_metadata(
     )
 
 
-def _list_skills(source_path: str, workspace: str = None) -> list[SkillMetadata]:
+def _list_skills(workspace: str) -> list[SkillMetadata]:
     """List all skills from a directory.
-    Scans directory for subdirectories containing SKILL.md files, reads their content,
+    Scans directory recursively for SKILL.md files, reads their content,
     parses YAML frontmatter, and returns skill metadata.
     Expected structure:
-        source_path/
-        ├── skill-1-name/
-        │   ├── SKILL.md        # Required
-        │   └── helper.py       # Optional
+        skill_path/
+        ├── group-a/
+        │   ├── skill-1-name/
+        │   │   ├── SKILL.md    # Required
+        │   │   ├── scripts
+        │   │   │   └── hooks.py   # Optional
         ├── skill-2-name/
         │   ├── SKILL.md        # Required
     Args:
-        source_path: Path to the skills directory
-        workspace: Path to workspace directory. If provided, skills will be copied to workspace/skills/
+        workspace: Path to the workspace directory containing skills
     Returns:
         List of skill metadata from successfully parsed SKILL.md files
     """
     skills: list[SkillMetadata] = []
 
-    # Convert to Path object for easier manipulation
+    # Convert to Path objects for easier manipulation
+    workspace_path = Path(workspace).resolve()
+    source_path = fc.get_workspace_skill_root(workspace)
     base_path = Path(source_path)
 
     # Check if source path exists
@@ -185,30 +188,12 @@ def _list_skills(source_path: str, workspace: str = None) -> list[SkillMetadata]
         warning(f"Skills source path is not a directory: {source_path}")
         return []
 
-    # Iterate through all subdirectories
+    # Iterate through all skill directories recursively by SKILL.md marker file
     try:
-        for skill_dir in base_path.iterdir():
-            if not skill_dir.is_dir():
+        for skill_md_path in sorted(base_path.rglob("SKILL.md")):
+            if not skill_md_path.is_file():
                 continue
-
-            # Check if SKILL.md exists in this directory
-            skill_md_path = skill_dir / "SKILL.md"
-            if not skill_md_path.exists():
-                continue
-
-            # Copy skill directory to workspace if workspace is provided
-            if workspace:
-                try:
-                    workspace_skills_dir = Path(workspace) / "skills"
-                    workspace_skills_dir.mkdir(parents=True, exist_ok=True)
-                    dest_skill_dir = workspace_skills_dir / skill_dir.name
-
-                    # Copy the entire skill directory to workspace
-                    if dest_skill_dir.exists():
-                        shutil.rmtree(dest_skill_dir)
-                    shutil.copytree(skill_dir, dest_skill_dir)
-                except Exception as e:
-                    warning(f"Failed to copy skill directory {skill_dir} to workspace: {e}")
+            skill_dir = skill_md_path.parent
 
             # Read SKILL.md content
             try:
@@ -224,16 +209,16 @@ def _list_skills(source_path: str, workspace: str = None) -> list[SkillMetadata]
             # Parse metadata
             skill_metadata = _parse_skill_metadata(
                 content=content,
-                skill_path=str(skill_md_path),
+                skill_path=skill_md_path.resolve().relative_to(workspace_path).as_posix(),
                 directory_name=skill_dir.name
             )
             if skill_metadata:
                 skill_metadata['script'] = {}
                 script_dir = skill_dir / "scripts"
                 if script_dir.exists() and script_dir.is_dir():
-                    for f in script_dir.iterdir():
+                    for f in sorted(script_dir.iterdir()):
                         if f.is_file() and f.name != '__init__.py' and f.name != 'hooks.py':
-                            skill_metadata['script'][f.name] = str(f)
+                            skill_metadata['script'][f.name] = f.resolve().relative_to(workspace_path).as_posix()
                 skills.append(skill_metadata)
 
     except PermissionError as e:
@@ -252,17 +237,26 @@ def list_skills_in_format(skills: list[SkillMetadata], workspace: str = '.', abl
     Returns:
         A formatted string listing each skill's name, description, and path
     """
+    def _format_display_path(path_value: str) -> str:
+        p = Path(path_value)
+        if not p.is_absolute():
+            return str(p)
+        try:
+            return str(p.relative_to(Path(workspace)))
+        except ValueError:
+            return str(p)
+
     result_lines = []
     count=1
     for skill in skills:
         if (not able_to_list) or skill['name'] in able_to_list:
             result_lines.append(f"{count}. Skill Name: {skill['name']}")
             result_lines.append(f"   Skill Description: {skill['description']}")
-            result_lines.append(f"   Skill Path: {Path(skill['path']).relative_to(Path(workspace))}")
+            result_lines.append(f"   Skill Path: {_format_display_path(skill['path'])}")
             if skill.get('script'):
                 result_lines.append("   Script Path:")
                 for fname, fpath in skill['script'].items():
-                    result_lines.append(f"     - {fname}: {Path(fpath).relative_to(Path(workspace))}")
+                    result_lines.append(f"     - {fname}: {_format_display_path(fpath)}")
             count+=1
     return "\n".join(result_lines)
 
@@ -295,10 +289,10 @@ class ListSkill(UCTool):
         Returns:
             A formatted string containing information about all available skills.
         """
-        skills_path = Path(self.workspace) / ".ucagent/skills"
+        skills_path = Path(fc.get_workspace_skill_root(self.workspace))
         if not skills_path.exists():
             raise ValueError(f"Skill directory not found: {skills_path}. You need to start UCAgent with arg(--use-skill) to copy skills into the workspace.")
-        skills = _list_skills(str(skills_path), workspace=None)
+        skills = _list_skills(self.workspace)
 
         if not skills:
             raise ValueError(f"No available skills found in skill directory {skills_path}. Skills should be subdirectories containing a SKILL.md file.")

--- a/ucagent/util/functions.py
+++ b/ucagent/util/functions.py
@@ -758,17 +758,19 @@ def copytree_incremental(src_dir, dst_dir, skip_existing=True, enable_skill_list
 
     copied_skills = []
     
-    # get all skills in src_dir
-    all_skills = []
-    for item in os.listdir(src_dir):
-        item_path = os.path.join(src_dir, item)
-        if os.path.isdir(item_path):
-            all_skills.append(item)
+    # recursively discover skills by SKILL.md
+    skill_dir_map = {}
+    for root, _, files in os.walk(src_dir):
+        if "SKILL.md" not in files:
+            continue
+        skill_name = os.path.basename(root)
+        skill_dir_map[skill_name] = root
+    all_skills = list(skill_dir_map.keys())
     
     # determine which skills to copy based on enable_skill_list and disable_skill_list
     skills_to_copy = []
     if enable_skill_list:
-        skills_to_copy = [skill for skill in enable_skill_list if skill in all_skills]
+        skills_to_copy = [skill for skill in enable_skill_list if skill in skill_dir_map]
     elif disable_skill_list:
         skills_to_copy = [skill for skill in all_skills if skill not in disable_skill_list]
     else:
@@ -776,10 +778,11 @@ def copytree_incremental(src_dir, dst_dir, skip_existing=True, enable_skill_list
     
     # copy skill
     for skill in skills_to_copy:
-        src_skill_dir = os.path.join(src_dir, skill)
-        dst_skill_dir = os.path.join(dst_dir, skill) 
-        if not os.path.exists(src_skill_dir):
+        src_skill_dir = skill_dir_map.get(skill)
+        if not src_skill_dir or not os.path.exists(src_skill_dir):
             continue
+        skill_rel_dir = os.path.relpath(src_skill_dir, src_dir)
+        dst_skill_dir = os.path.join(dst_dir, skill_rel_dir)
         if not os.path.exists(dst_skill_dir):
             os.makedirs(dst_skill_dir)
         for root, dirs, files in os.walk(src_skill_dir):
@@ -802,6 +805,18 @@ def copytree_incremental(src_dir, dst_dir, skip_existing=True, enable_skill_list
                 copied_skills.append(skill)
     
     return copied_skills
+
+
+def find_skill_dir_by_name(root_dir, target_dir_name):
+    if not root_dir or not target_dir_name:
+        return None
+    if not os.path.isdir(root_dir):
+        return None
+
+    for root, dirs, _ in os.walk(root_dir):
+        if target_dir_name in dirs:
+            return os.path.join(root, target_dir_name)
+    return None
 
 def render_template_dir(workspace, template_dir, kwargs):
     """
@@ -2318,7 +2333,7 @@ def copy_skill_files(cfg, workspace, root_dir):
         workspace: Workspace directory path
         root_dir: Root directory path
     """
-    dst_path = os.path.join(workspace, ".ucagent/skills")
+    dst_path = get_workspace_skill_root(workspace)
     src_paths=[]
     # default skills path
     default_skill_path = os.path.join(root_dir,"lang",cfg.lang,"skills")
@@ -2377,3 +2392,6 @@ def find_most_similar_strings(a: Union[str, List[str]], b: List[str]) -> Union[i
                 best_index = idx
         result.append((a_item, best_index))
     return result
+
+def get_workspace_skill_root(workspace):
+    return get_abs_path_cwd_ucagent(workspace, "skills")

--- a/ucagent/verify_agent.py
+++ b/ucagent/verify_agent.py
@@ -581,7 +581,7 @@ class VerifyAgent:
         """Get the default system prompt for the agent. And if skill is enabled, include skill prompt and skill list."""
         system = self.cfg.mission.prompt.get_value("system", "").strip()
         if self.cfg.skill.use_skill:
-            formatted_skill_list = list_skills_in_format(_list_skills(self.workspace+"/.ucagent/skills"),self.workspace,self.cfg.skill.general_skill_list)
+            formatted_skill_list = list_skills_in_format(_list_skills(self.workspace),self.workspace,self.cfg.skill.general_skill_list)
             skill_prompt = self.cfg.mission.prompt.get_value("skill_system", "").replace("{general_skill_list}", formatted_skill_list)
             system = system.replace("{skill_system}", skill_prompt)
         else:


### PR DESCRIPTION

This pull request refactors and improves the way skills are discovered, listed, and managed within the workspace. The main changes standardize skill directory handling to support recursive discovery, improve robustness when resolving skill paths, and add utility functions to simplify code and avoid duplication. These updates ensure that skills can be organized in nested directories, are correctly identified, and their metadata and scripts are accurately listed and displayed.

**Skill discovery and path management:**

* Refactored `_list_skills` in `ucagent/tools/skill.py` to recursively discover all `SKILL.md` files within the workspace, enabling support for nested skill directories and ensuring relative paths are used for skill metadata and scripts. [[1]](diffhunk://#diff-d4abd895d86b33e42be1150fdbc466b3d1ba89c046270540562453fae106747fL157-R179) [[2]](diffhunk://#diff-d4abd895d86b33e42be1150fdbc466b3d1ba89c046270540562453fae106747fL188-R196) [[3]](diffhunk://#diff-d4abd895d86b33e42be1150fdbc466b3d1ba89c046270540562453fae106747fL227-R221)
* Updated all usages of skill directory resolution to use the new utility function `get_workspace_skill_root`, replacing hardcoded paths and improving maintainability. [[1]](diffhunk://#diff-4fe38dafa95a5679983112be4d229f5a0bd5f4602b51f9fe9d607e838ac775dfL658-R658) [[2]](diffhunk://#diff-5d31940d40a7735e74485d5ea60e632b16cec4f193ab21ee9e4e0da0c8031227L233-R227) [[3]](diffhunk://#diff-5d31940d40a7735e74485d5ea60e632b16cec4f193ab21ee9e4e0da0c8031227R332-R336) [[4]](diffhunk://#diff-f33dd062cfb695b4ac798777d940d76c832d2c385f073077fce24ac7cb63261aL2321-R2336) [[5]](diffhunk://#diff-d4abd895d86b33e42be1150fdbc466b3d1ba89c046270540562453fae106747fL298-R295) [[6]](diffhunk://#diff-2bdd7cb7eda1738e52e34aa465f0c9b1c5e90a1aac7ee1c7d1efb6b4a7aa2260L584-R584)

**Skill directory validation and lookup:**

* Replaced manual directory checks with a new helper function `find_skill_dir_by_name`, which searches for a skill directory by name within the workspace, ensuring correct resolution even for nested skills. [[1]](diffhunk://#diff-4fe38dafa95a5679983112be4d229f5a0bd5f4602b51f9fe9d607e838ac775dfL748-R752) [[2]](diffhunk://#diff-5d31940d40a7735e74485d5ea60e632b16cec4f193ab21ee9e4e0da0c8031227L233-R227) [[3]](diffhunk://#diff-f33dd062cfb695b4ac798777d940d76c832d2c385f073077fce24ac7cb63261aR809-R820)

**Formatting and display improvements:**

* Enhanced `list_skills_in_format` to handle both absolute and relative skill/script paths, ensuring paths are displayed relative to the workspace for clarity.

**Skill copying and initialization:**

* Modified `copytree_incremental` to recursively discover and copy skills by finding all directories containing a `SKILL.md` file, preserving nested skill structures.


