### PR TITLE
Add optional reference model workflow and shared startup banner

### DIFF
--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+import tempfile
+import unittest
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.abspath(os.path.join(current_dir, "..")))
+
+from ucagent.util.config import load_yaml_with_env_vars
+
+
+class TestConfigLoader(unittest.TestCase):
+    def test_load_yaml_with_negated_bool_scalars(self):
+        yaml_content = """
+plain_true: true
+not_true: not true
+minus_false: -false
+list_values:
+  - not false
+  - -true
+plain_text: not enabled
+"""
+        with tempfile.NamedTemporaryFile('w', suffix='.yaml', delete=False, encoding='utf-8') as handle:
+            handle.write(yaml_content)
+            yaml_path = handle.name
+
+        try:
+            data = load_yaml_with_env_vars(yaml_path)
+        finally:
+            os.unlink(yaml_path)
+
+        self.assertIs(data['plain_true'], True)
+        self.assertIs(data['not_true'], False)
+        self.assertIs(data['minus_false'], True)
+        self.assertEqual(data['list_values'], [True, False])
+        self.assertEqual(data['plain_text'], 'not enabled')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/ucagent/checkers/unity_test.py
+++ b/ucagent/checkers/unity_test.py
@@ -638,7 +638,8 @@ class BaseUnityChipCheckerTestCase(Checker):
     """
 
     def __init__(self, doc_func_check=None, test_dir=None, doc_bug_analysis=None, min_tests=1, timeout=15, ignore_tc_prefix="",
-                 data_key=None, ret_std_error=True, ret_std_out=True, batch_size=1000, need_human_check=False, **extra_kwargs):
+                 data_key=None, ret_std_error=True, ret_std_out=True, batch_size=1000, need_human_check=False,
+                 no_args_check=True, args_pattern=None, args_test_func_prefix=None, **extra_kwargs):
         self.doc_func_check = doc_func_check
         self.doc_bug_analysis = doc_bug_analysis
         self.test_dir = test_dir
@@ -652,6 +653,9 @@ class BaseUnityChipCheckerTestCase(Checker):
         self.batch_size = batch_size
         self.run_test = RunUnityChipTest()
         self.set_human_check_needed(need_human_check)
+        self.args_check = not no_args_check
+        self.args_pattern = args_pattern
+        self.args_test_func_prefix = args_test_func_prefix
 
     def set_workspace(self, workspace: str):
         """
@@ -665,6 +669,80 @@ class BaseUnityChipCheckerTestCase(Checker):
             if not os.path.exists(self.get_path(self.test_dir)):
                 warning(f"Test directory '{self.test_dir}' does not exist in workspace.")
         return self
+
+    def _check_test_func_args(self, report, str_out, str_err):
+        """
+        Check test function argument names against self.args_pattern.
+
+        For each test case in the report whose name starts with self.args_test_func_prefix
+        (or all test cases if args_test_func_prefix is None), verify that the positional
+        argument names match self.args_pattern.  For example, args_pattern=["env", "ref_model"]
+        requires position-0 to be "env" and position-1 to be "ref_model".
+
+        On failure, report["run_test_success"] is set to False and the failure reasons
+        are appended to str_err.
+        """
+        if not self.args_check or not self.args_pattern:
+            return report, str_out, str_err
+        test_cases = report.get("tests", {}).get("test_cases", {})
+        if not test_cases:
+            return report, str_out, str_err
+        # Group function names to check by file (deduplicated), one pass over test_cases
+        file_funcs = {}  # file_rel -> set of func_names to check
+        for tc_key in test_cases:
+            # tc_key format: "path/to/test_file.py::func_name" or "path/to/test_file.py::func_name[param]"
+            parts = tc_key.split("::")
+            if len(parts) < 2:
+                continue
+            file_rel = parts[0]
+            func_name = parts[1].split("[")[0]  # strip parametrize suffix
+            # Apply prefix filter
+            if self.args_test_func_prefix and not func_name.startswith(self.args_test_func_prefix):
+                continue
+            file_funcs.setdefault(file_rel, set()).add(func_name)
+        failures = []
+        # Read and parse each file exactly once, then check all required functions in it
+        for file_rel, func_names in file_funcs.items():
+            file_path = self.get_path(file_rel)
+            if not os.path.exists(file_path):
+                continue
+            try:
+                with open(file_path, "r", encoding="utf-8") as _f:
+                    source = _f.read()
+                tree = ast.parse(source)
+            except Exception as e:
+                warning(f"[args_check] Failed to parse '{file_rel}': {e}")
+                continue
+            # Build a map of func_name -> FunctionDef node for all functions in this file
+            func_nodes = {}
+            for node in ast.walk(tree):
+                if isinstance(node, ast.FunctionDef) and node.name in func_names:
+                    func_nodes[node.name] = node
+            for func_name in func_names:
+                func_node = func_nodes.get(func_name)
+                if func_node is None:
+                    continue
+                args = [arg.arg for arg in func_node.args.args]
+                line_no = func_node.lineno
+                for i, expected_arg in enumerate(self.args_pattern):
+                    if expected_arg is None:
+                        continue  # None means no constraint at this position
+                    if i >= len(args):
+                        failures.append(
+                            f"'{func_name}' at {file_rel}:{line_no}: "
+                            f"expected argument[{i}] to be '{expected_arg}', "
+                            f"but the function only has {len(args)} argument(s)."
+                        )
+                    elif args[i] != expected_arg:
+                        failures.append(
+                            f"'{func_name}' at {file_rel}:{line_no}: "
+                            f"argument[{i}] expected '{expected_arg}', got '{args[i]}'."
+                        )
+        if failures:
+            report["run_test_success"] = False
+            failure_msg = "\n[Args Pattern Check Failed]\n" + "\n".join(f"  - {f}" for f in failures)
+            str_err = (str_err or "") + failure_msg
+        return report, str_out, str_err
 
     def do_check(self, pytest_args="", timeout=0, is_complete=False, **kw) -> Tuple[bool, str]:
         """
@@ -684,12 +762,14 @@ class BaseUnityChipCheckerTestCase(Checker):
             pytest_args = pytest_args if pytest_args else "."
             pytest_args = pytest_args.split()
             pytest_args = ["-k", f"not {self.ignore_tc_prefix}"] + pytest_args
-        return self.run_test.do(
+        report, str_out, str_err = self.run_test.do(
             self.test_dir,
             pytest_ex_args=pytest_args,
             return_stdout=True, return_stderr=True, return_all_checks=True, timeout=timeout,
             **kw
         )
+        report, str_out, str_err = self._check_test_func_args(report, str_out, str_err)
+        return report, str_out, str_err
 
 
 class UnityChipCheckerTestFree(BaseUnityChipCheckerTestCase):

--- a/ucagent/checkers/unity_test.py
+++ b/ucagent/checkers/unity_test.py
@@ -639,7 +639,9 @@ class BaseUnityChipCheckerTestCase(Checker):
 
     def __init__(self, doc_func_check=None, test_dir=None, doc_bug_analysis=None, min_tests=1, timeout=15, ignore_tc_prefix="",
                  data_key=None, ret_std_error=True, ret_std_out=True, batch_size=1000, need_human_check=False,
-                 no_args_check=True, args_pattern=None, args_test_func_prefix=None, **extra_kwargs):
+                 args_check=False, args_pattern=None, args_test_func_prefix=None,
+                 args_error_msg=None,
+                 **extra_kwargs):
         self.doc_func_check = doc_func_check
         self.doc_bug_analysis = doc_bug_analysis
         self.test_dir = test_dir
@@ -653,9 +655,10 @@ class BaseUnityChipCheckerTestCase(Checker):
         self.batch_size = batch_size
         self.run_test = RunUnityChipTest()
         self.set_human_check_needed(need_human_check)
-        self.args_check = not no_args_check
+        self.args_check = args_check
         self.args_pattern = args_pattern
         self.args_test_func_prefix = args_test_func_prefix
+        self.args_error_msg = args_error_msg
 
     def set_workspace(self, workspace: str):
         """
@@ -682,66 +685,44 @@ class BaseUnityChipCheckerTestCase(Checker):
         On failure, report["run_test_success"] is set to False and the failure reasons
         are appended to str_err.
         """
+        if report.get("run_test_success") is False:
+            return report, str_out, str_err
         if not self.args_check or not self.args_pattern:
             return report, str_out, str_err
         test_cases = report.get("tests", {}).get("test_cases", {})
         if not test_cases:
             return report, str_out, str_err
-        # Group function names to check by file (deduplicated), one pass over test_cases
-        file_funcs = {}  # file_rel -> set of func_names to check
-        for tc_key in test_cases:
-            # tc_key format: "path/to/test_file.py::func_name" or "path/to/test_file.py::func_name[param]"
-            parts = tc_key.split("::")
-            if len(parts) < 2:
-                continue
-            file_rel = parts[0]
-            func_name = parts[1].split("[")[0]  # strip parametrize suffix
-            # Apply prefix filter
-            if self.args_test_func_prefix and not func_name.startswith(self.args_test_func_prefix):
-                continue
-            file_funcs.setdefault(file_rel, set()).add(func_name)
+        tc_blocks = fc.tc_list_as_loc_blocks(test_cases.keys(),
+                                             target_tc_prefix=self.args_test_func_prefix)
         failures = []
-        # Read and parse each file exactly once, then check all required functions in it
-        for file_rel, func_names in file_funcs.items():
-            file_path = self.get_path(file_rel)
-            if not os.path.exists(file_path):
-                continue
-            try:
-                with open(file_path, "r", encoding="utf-8") as _f:
-                    source = _f.read()
-                tree = ast.parse(source)
-            except Exception as e:
-                warning(f"[args_check] Failed to parse '{file_rel}': {e}")
-                continue
-            # Build a map of func_name -> FunctionDef node for all functions in this file
-            func_nodes = {}
-            for node in ast.walk(tree):
-                if isinstance(node, ast.FunctionDef) and node.name in func_names:
-                    func_nodes[node.name] = node
-            for func_name in func_names:
-                func_node = func_nodes.get(func_name)
-                if func_node is None:
+        def check_args(func_code_str):
+            arg_list = fc.get_func_params_regex(func_code_str)
+            warning(f"find mis-match args: {arg_list}")
+            if len(arg_list) < len(self.args_pattern):
+                return False
+            for i, arg_pt in enumerate(self.args_pattern):
+                if not fc.match_pattern_list(arg_list[i],
+                                             arg_pt if isinstance(arg_pt, list) else [arg_pt]):
+                    return False
+            return True
+        for _, v in fc.check_file_block(tc_blocks,
+                                        self.workspace,
+                                        check_args).items():
+            for func_name, is_pass in v.items():
+                if is_pass:
                     continue
-                args = [arg.arg for arg in func_node.args.args]
-                line_no = func_node.lineno
-                for i, expected_arg in enumerate(self.args_pattern):
-                    if expected_arg is None:
-                        continue  # None means no constraint at this position
-                    if i >= len(args):
-                        failures.append(
-                            f"'{func_name}' at {file_rel}:{line_no}: "
-                            f"expected argument[{i}] to be '{expected_arg}', "
-                            f"but the function only has {len(args)} argument(s)."
-                        )
-                    elif args[i] != expected_arg:
-                        failures.append(
-                            f"'{func_name}' at {file_rel}:{line_no}: "
-                            f"argument[{i}] expected '{expected_arg}', got '{args[i]}'."
-                        )
-        if failures:
+                failures.append(func_name)
+        if len(failures) > 0:
             report["run_test_success"] = False
-            failure_msg = "\n[Args Pattern Check Failed]\n" + "\n".join(f"  - {f}" for f in failures)
-            str_err = (str_err or "") + failure_msg
+            max_show = 10
+            error_msg = self.args_error_msg
+            if not error_msg:
+                error_msg = f"do not match the required argument pattern {self.args_pattern}"
+            str_err  = f"Argument name check failed for {len(failures)} test functions. " + \
+                       f"The flollowing test functions have argument names that {error_msg}: {', '.join(failures[:max_show])}" + \
+                       (f", etc." if len(failures) > max_show else "") + \
+                        " Please fix the arguments of those test functions to match the required pattern."
+            str_out = ""
         return report, str_out, str_err
 
     def do_check(self, pytest_args="", timeout=0, is_complete=False, **kw) -> Tuple[bool, str]:
@@ -1041,6 +1022,7 @@ class UnityChipCheckerDutApiTest(BaseUnityChipCheckerTestCase):
             pytest_ex_args=targets,
             return_stdout=True, return_stderr=True, return_all_checks=True, timeout=timeout
         )
+        report, str_out, str_err = self._check_test_func_args(report, str_out, str_err)
         test_pass, test_msg = fc.is_run_report_pass(report, str_out, str_err)
         if not test_pass:
             return False, test_msg

--- a/ucagent/cli.py
+++ b/ucagent/cli.py
@@ -820,6 +820,7 @@ def run() -> None:
             master_cmd = f"connect_master_to {master_addr}{extra_client_opts}"
         init_cmds += [master_cmd]
 
+    init_cmds.append("logo_and_version")
     if args.icmd:
         init_cmds += args.icmd
     

--- a/ucagent/lang/zh/config/default.yaml
+++ b/ucagent/lang/zh/config/default.yaml
@@ -738,7 +738,7 @@ stage:
 
   - name: reference_model_implementation
     desc: "参考模型实现"
-    ignore: $(IGNORE_REF_MODEL: true)
+    ignore: not $(NEED_REF_MODEL: false)
     task:
       - "请参考{OUT}/tests/{DUT}_api.py中的API接口创建DUT参考模型"
       - "第1步：分析{DUT}的功能和API接口，设计参考模型的结构和接口"
@@ -754,7 +754,7 @@ stage:
 
   - name: reference_model_fixture_imp
     desc: "参考模型fixture实现与测试"
-    ignore: $(IGNORE_REF_MODEL: true)
+    ignore: not $(NEED_REF_MODEL: false)
     task:
       - "请在{OUT}/tests/{DUT}_api.py实现fixure，名称为ref_model"
       - "第1步：实现ref_model fixture，负责创建参考模型实例，并在测试结束后进行清理"
@@ -964,6 +964,8 @@ stage:
           - "  - 如果源码不存在，需要给出可能的设计缺陷分析和修复建议"
           - "  - 不能为了让测试通过而修改测试逻辑，例如使用不合理的断言等，必须确保测试逻辑正确，否则会掩盖bug"
           - "完成进度：{COMPLETED_CASES}/{TOTAL_CASES}个测试用例已完成"
+          - "是否已启用参考模型": $(NEED_REF_MODEL: false)
+          - "如果启用了参考模型，请特别关注测试用例的比对验证结果，如果发现参考模型实现有误，也请及时修正参考模型代码，确保参考模型的正确性"
         reference_files:
           - "Guide_Doc/dut_test_case.md"
           - "Guide_Doc/dut_bug_analysis.md"
@@ -1100,6 +1102,8 @@ stage:
       - " - 如果用例有测试区间，需要通过pytest的参数化模式进行区间控制"
       - " - 其他用例要求请参考文档 Guide_Doc/dut_test_case.md"
       - " - 需要有合理的断言来检查输出是否符合预期，是否正确"
+      - "是否已启用参考模型": $(NEED_REF_MODEL: false)
+      - "如果启用了参考模型，请特别关注测试用例的比对验证结果，如果发现参考模型实现有误，也请及时修正参考模型代码，确保参考模型的正确性"
     checker:
       - name: no_conftest_file
         clss: FilesMustNotExist
@@ -1114,6 +1118,10 @@ stage:
           doc_bug_analysis: "{OUT}/{DUT}_bug_analysis.md"
           test_dir: "{OUT}/tests"
           target_test_file: "{OUT}/tests/test_{DUT}_random*.py"
+          args_check: $(NEED_REF_MODEL: false)
+          args_pattern: ["env", "ref_model"]
+          args_test_func_prefix: "test_random_"
+          args_error_msg: "第一个参数必须为env，第二个参数必须ref_model"
     need_human_check: false # 验证复杂DUT时建议开启该人工检查
     output_files:
       - "{OUT}/tests/test_{DUT}_random*.py"

--- a/ucagent/lang/zh/config/default.yaml
+++ b/ucagent/lang/zh/config/default.yaml
@@ -104,6 +104,7 @@ mission:
           - "(4) 通过Complete工具确认完成当前阶段的任务"
         - "你需要完成所有阶段的任务，才算完成整个验证任务"
         - "不清楚目标时，需要通过工具RoleInfo获取角色信息和基本指导"
+        - "如果启用了ref_model fixture，则必须通过ref_model的接口来进行比对验证"
       random:
         - "如果工具Complete出现超时错误，请调大timeout参数重试"
         - "判断是否完成阶段任务时，优先使用Complete工具，其次是Check工具（例如Batch任务）"
@@ -734,6 +735,59 @@ stage:
           target_file: "{OUT}/tests/{DUT}_api.py"
     reference_files:
       - "Guide_Doc/dut_api_instruction.md"
+
+  - name: reference_model_implementation
+    desc: "参考模型实现"
+    ignore: $(IGNORE_RM_IMP: true)
+    task:
+      - "请参考{OUT}/tests/{DUT}_api.py中的API接口创建DUT参考模型"
+      - "第1步：分析{DUT}的功能和API接口，设计参考模型的结构和接口"
+      - "第2步：实现参考模型，确保其功能与{DUT}的API接口一致，能够正确模拟{DUT}的行为"
+      - "第3步：将参考模型代码写入{OUT}/tests/{DUT}_reference_model.py中，确保代码有注释，便于理解和使用，请使用{DOC_GEN_LANG}编写注释"
+      - "注意："
+      - "  参考模型的主要目的是提供一个功能正确的模型，供后续测试用例进行比对验证，因此参考模型的功能实现需要尽可能完整和正确"
+      - "  参考模型的实现可以相对简单，但必须能够正确模拟{DUT}的核心功能"
+      - "  注意{DUT}相关的文件名，用例名等大小写敏感"
+    output_files:
+      - "{OUT}/tests/{DUT}_reference_model.py"
+      - "{OUT}/tests/test_{DUT}_reference_model.py"
+
+  - name: reference_model_fixture_imp
+    desc: "参考模型fixture实现与测试"
+    ignore: $(IGNORE_RM_IMP: true)
+    task:
+      - "请在{OUT}/tests/{DUT}_api.py实现fixure，名称为ref_model"
+      - "第1步：实现ref_model fixture，负责创建参考模型实例，并在测试结束后进行清理"
+      - "第2步：编写简单的测试用例验证参考模型的功能正确性，测试用例写入文件{OUT}/tests/test_{DUT}_reference_model.py, 测试函数命名格式为test_api_{DUT}_reference_model_<Name>"
+      - "  测试用例的第一个参数为ref_model (pytest fixture)"
+      - "第3步：确保测试用例能够正确验证参考模型的功能，并且所有测试用例都必须通过，请通过RunTestCases('test_{DUT}_reference_model.py')运行测试"
+      - "参考模板如下："
+      - "  @pytest.fixture(scope='function')"
+      - "  def ref_model():"
+      - "      # 创建参考模型实例"
+      - "      model = YourReferenceModel()  # 替换为实际参考模型的创建代码"
+      - "      yield model"
+      - "      # 清理参考模型实例"
+      - "      model.cleanup()  # 替换为实际参考模型的清理代码"
+      - "注意："
+      - "  scope必须设置为function，确保每个测试函数都能获得一个独立的参考模型实例"
+    checker:
+      - name: reference_model_fixture_check
+        clss: "UnityChipCheckerBaseFixture"
+        args:
+          target_file: "{OUT}/tests/{DUT}_api.py"
+          fixture_name: "ref_model"
+      - name: reference_model_test_check
+        clss: "UnityChipCheckerTestMustPass"
+        args:
+          target_file: "{OUT}/tests/test_{DUT}_reference_model.py"
+          test_dir: "{OUT}/tests"
+          test_prefix: "test_api_{DUT}_reference_model_"
+          first_arg: "ref_model"
+    output_files:
+      - "{OUT}/tests/{DUT}_reference_model.py"
+      - "{OUT}/tests/test_{DUT}_reference_model.py"
+
   - name: basic_api_functional_test
     desc: "基础API功能正确性测试"
     task:
@@ -766,6 +820,7 @@ stage:
       - "  - 如果测试函数和多个功能点关联，需要多次调用mark_function()"
       - "  - 如果需要，请修复已经实现的API函数和Env fixture，如修复时序、等待、超时、Mock组件等问题"
       - "  - 注意{DUT}相关的文件名，用例名等大小写敏感"
+      - "  - 如果定义了参考模型，请在测试中使用ref_model fixture进行比对验证，如果发现参考模型实现有误，也请及时修正参考模型代码，确保测试通过"
     checker:
       - name: no_conftest_file
         clss: FilesMustNotExist
@@ -781,6 +836,9 @@ stage:
           target_file_tests: "{OUT}/tests/test_{DUT}_api*.py"
           doc_func_check: "{OUT}/{DUT}_functions_and_checks.md"
           doc_bug_analysis: "{OUT}/{DUT}_bug_analysis.md"
+          no_args_check: $(IGNORE_RM_IMP: true)
+          args_pattern: ["env", "ref_model"]
+          args_test_func_prefix: "test_api_{DUT}_"
     need_human_check: false # 验证复杂DUT时建议开启该人工检查
     reference_files:
       - "Guide_Doc/dut_api_instruction.md"
@@ -798,7 +856,7 @@ stage:
       - "第2步：根据功能点个数创建一个或者多个测试文件test_<名称>.py，文件名要有意义"
       - "第3步：在测试文件中按以下顺序创建测试函数："
       - "  - 0) 每个测试文件开头都需要用 from {DUT}_api import * 来导入env(pytest fixture)"
-      - "  - 1) 每个测试函数以test_开头，第一个参数为env(pytest fixture)，可以根据需要添加其他参数"
+      - "  - 1) 每个测试函数以test_开头，第一个参数为env(pytest fixture)，如果有ref_model fixture则第二个参数为ref_model，可以根据需要添加其他参数"
       - "  - 2) 每个测试函数的最开始添加功能覆盖标记：env.dut.fc_cover['FG-XXX'].mark_function('FC-YYY', test_func, ['CK-ZZZ', ...])"
       - "  - 3) 添加详细的TODO注释说明要测什么"
       - "  - 4) 最后添加assert False, 'Not implemented'防止意外通过"
@@ -834,6 +892,9 @@ stage:
           data_key: "TEST_TEMPLATE_IMP_REPORT"
           batch_size: $(BATCH_SIZE_TMP: 20)
           template_must_fail: $(TEMPLATE_MUST_FAIL: true)
+          no_args_check: $(IGNORE_RM_IMP: true)
+          args_pattern: ["env", "ref_model"]
+          args_test_func_prefix: "test_api_{DUT}_"
     need_human_check: false # 验证复杂DUT时建议开启该人工检查
     reference_files:
       - "Guide_Doc/dut_test_template.md"
@@ -882,7 +943,7 @@ stage:
           - "第2步：将以下空的测试模板填充为可执行代码": "{LIST_CURRENT_CASES}"
           - "第3步：使用API接口调用芯片功能，避免直接操作底层信号"
           - "第4步：设计充分的测试数据：典型值、边界值、特殊值"
-          - "第5步：添加断言检查输出是否符合预期（Eg: assert output == excepted_output, error_msg）"
+          - "第5步：添加断言检查输出是否符合预期（Eg: assert output == excepted_output, error_msg），如果有ref_model fixture，可以通过assert output == ref_model.some_function(input)来进行比对验证"
           - "第6步：完成上述所有测试用例后，立即用RunTestCases('{TEST_BATCH_RUN_ARGS}')检查运行结果"
           - "第7步：分析测试结果："
           - "  - 如果Pass且结果符合预期，则继续通过Check工具进行阶段检查"

--- a/ucagent/lang/zh/config/default.yaml
+++ b/ucagent/lang/zh/config/default.yaml
@@ -738,7 +738,7 @@ stage:
 
   - name: reference_model_implementation
     desc: "参考模型实现"
-    ignore: $(IGNORE_RM_IMP: true)
+    ignore: $(IGNORE_REF_MODEL: true)
     task:
       - "请参考{OUT}/tests/{DUT}_api.py中的API接口创建DUT参考模型"
       - "第1步：分析{DUT}的功能和API接口，设计参考模型的结构和接口"
@@ -754,7 +754,7 @@ stage:
 
   - name: reference_model_fixture_imp
     desc: "参考模型fixture实现与测试"
-    ignore: $(IGNORE_RM_IMP: true)
+    ignore: $(IGNORE_REF_MODEL: true)
     task:
       - "请在{OUT}/tests/{DUT}_api.py实现fixure，名称为ref_model"
       - "第1步：实现ref_model fixture，负责创建参考模型实例，并在测试结束后进行清理"
@@ -821,6 +821,7 @@ stage:
       - "  - 如果需要，请修复已经实现的API函数和Env fixture，如修复时序、等待、超时、Mock组件等问题"
       - "  - 注意{DUT}相关的文件名，用例名等大小写敏感"
       - "  - 如果定义了参考模型，请在测试中使用ref_model fixture进行比对验证，如果发现参考模型实现有误，也请及时修正参考模型代码，确保测试通过"
+      - "是否已启用参考模型": $(NEED_REF_MODEL: false)
     checker:
       - name: no_conftest_file
         clss: FilesMustNotExist
@@ -836,9 +837,10 @@ stage:
           target_file_tests: "{OUT}/tests/test_{DUT}_api*.py"
           doc_func_check: "{OUT}/{DUT}_functions_and_checks.md"
           doc_bug_analysis: "{OUT}/{DUT}_bug_analysis.md"
-          no_args_check: $(IGNORE_RM_IMP: true)
+          args_check: $(NEED_REF_MODEL: false)
           args_pattern: ["env", "ref_model"]
           args_test_func_prefix: "test_api_{DUT}_"
+          args_error_msg: "第一个参数必须为env，第二个参数必须ref_model"
     need_human_check: false # 验证复杂DUT时建议开启该人工检查
     reference_files:
       - "Guide_Doc/dut_api_instruction.md"
@@ -876,6 +878,7 @@ stage:
       - "参考Guide_Doc/dut_test_template.md了解模板格式"
       - "当前批次测点与对应说明节选如下": "{LIST_CK_FILE_BLOCKS}"
       - "完成进度：{COVERED_CKS}/{TOTAL_CKS}个测试用例模板已完成"
+      - "是否已启用参考模型": $(NEED_REF_MODEL: false)
     checker:
       - name: no_conftest_file
         clss: FilesMustNotExist
@@ -892,9 +895,10 @@ stage:
           data_key: "TEST_TEMPLATE_IMP_REPORT"
           batch_size: $(BATCH_SIZE_TMP: 20)
           template_must_fail: $(TEMPLATE_MUST_FAIL: true)
-          no_args_check: $(IGNORE_RM_IMP: true)
+          args_check: $(NEED_REF_MODEL: false)
           args_pattern: ["env", "ref_model"]
           args_test_func_prefix: "test_api_{DUT}_"
+          args_error_msg: "第一个参数必须为env，第二个参数必须ref_model"
     need_human_check: false # 验证复杂DUT时建议开启该人工检查
     reference_files:
       - "Guide_Doc/dut_test_template.md"

--- a/ucagent/lang/zh/doc/Guide_Doc/dut_test_case.md
+++ b/ucagent/lang/zh/doc/Guide_Doc/dut_test_case.md
@@ -48,6 +48,49 @@ def test_basic_functionality(env):
     assert actual_result == expected_result, f"预期: {expected_result}, 实际: {actual_result}"
 ```
 
+### API 测试函数的参数规范（重要）
+
+以 `test_api_{DUT}_` 为前缀的 **API 测试函数**有严格的参数顺序要求：
+
+| 参数位置 | 参数名 | 说明 |
+|---------|--------|------|
+| 第 1 个 | `env` | pytest fixture，必须 |
+| 第 2 个 | `ref_model` | 参考模型 fixture，若启用 ref_model 则必须（且必须是第二个参数） |
+| 其余 | 任意 | 按需添加其他 pytest fixture 或参数化参数 |
+
+**✅ 正确写法（启用了 ref_model）：**
+
+```python
+def test_api_{DUT}_add_basic(env, ref_model):
+    """测试加法API基础功能"""
+    env.dut.fc_cover["FG-API"].mark_function("FC-ADD", test_api_{DUT}_add_basic, ["CK-ADD-BASIC"])
+    result, carry = api_{DUT}_add(env, 10, 20)
+    expected = ref_model.add(10, 20)
+    assert result == expected, f"预期 {expected}，实际 {result}"
+```
+
+**✅ 正确写法（未启用 ref_model）：**
+
+```python
+def test_api_{DUT}_add_basic(env):
+    """测试加法API基础功能"""
+    env.dut.fc_cover["FG-API"].mark_function("FC-ADD", test_api_{DUT}_add_basic, ["CK-ADD-BASIC"])
+    result, carry = api_{DUT}_add(env, 10, 20)
+    assert result == 30, f"预期 30，实际 {result}"
+```
+
+**❌ 错误写法（参数顺序错误）：**
+
+```python
+# 错误：ref_model 必须是第二个参数
+def test_api_{DUT}_add_basic(ref_model, env): ...
+
+# 错误：第一个参数不是 env
+def test_api_{DUT}_add_basic(dut, env, ref_model): ...
+```
+
+> **注意：** 检查器会自动验证所有 `test_api_{DUT}_*` 函数的参数顺序。若启用了 `ref_model` fixture，则必须将 `ref_model` 作为第二个参数，否则检查将不通过。
+
 ## 覆盖率关联机制
 
 ### 标记语法
@@ -388,6 +431,11 @@ def test_mathematical_properties(env):
 
 
 **注意：**
+- `test_api_{DUT}_*` 函数的参数顺序有严格要求（由检查器自动验证）：
+  - 第 1 个参数必须为 `env`
+  - 若启用了参考模型（ref_model），第 2 个参数必须为 `ref_model`
+  - 正确示例：`def test_api_{DUT}_add_basic(env, ref_model):`
+  - 错误示例：`def test_api_{DUT}_add_basic(ref_model, env):` 或 `def test_api_{DUT}_add_basic(dut, env):`
 - 所有测试函数（test case function）都必须有合理assert：
   - 就算调用函数中有合理的assert，最外层test函数也需要有
   - assert 的基本格式为 assert output == expected_output, description

--- a/ucagent/server/api_terminal.py
+++ b/ucagent/server/api_terminal.py
@@ -627,19 +627,7 @@ class PdbWebTermServer:
 
     def _print_banner(self) -> None:
         """Print UCAgent ASCII art banner."""
-        try:
-            from ucagent.version import __version__
-        except ImportError:
-            __version__ = "unknown"
-
-        banner = f"""
-\u001b[34m   __  __   ______    ___                           __ \u001b[0m
-\u001b[34m  / / / /  / ____/   /   |   ____ _  ___    ____   / /_\u001b[0m
-\u001b[34m / / / /  / /       / /| |  / __ `/ / _ \\  / __ \\ / __/\u001b[0m
-\u001b[34m/ /_/ /  / /___    / ___ | / /_/ / /  __/ / / / // /_ \u001b[0m
-\u001b[34m\\____/   \\____/   /_/  |_| \\__, /  \\___/ /_/ /_/ \\__/\u001b[0m
-\u001b[34m                          /____/                       \u001b[0m \u001b[36mv{__version__}\u001b[0m
-"""
+        from ucagent.version import banner
         print(banner, file=sys.stderr)
 
     def get_status(self) -> Dict[str, Any]:

--- a/ucagent/setting.yaml
+++ b/ucagent/setting.yaml
@@ -104,7 +104,7 @@ launch:
     - "PASS_SUGGESTION_API_KEY": "$OPENAI_API_KEY"
 
 # Model support: openai, anthropic, google_genai
-model_type: openai
+model_type: $(UC_MODEL_TYPE: openai)
 
 openai:
   model_name: "$(OPENAI_MODEL: <your_chat_model_name>)"

--- a/ucagent/util/config.py
+++ b/ucagent/util/config.py
@@ -1,10 +1,35 @@
 # -*- coding: utf-8 -*-
 
 import os
+import re
 import yaml
 from typing import Dict, Any, Optional, Union, List
+from yaml.constructor import SafeConstructor
 from .functions import render_template, dump_as_json, replace_bash_var, get_abs_path_cwd_ucagent
 from .log import info
+
+
+_NEGATED_BOOL_PATTERN = re.compile(
+    r"^(?:not[ \t]+|-)(?:yes|no|true|false|on|off)$",
+    re.IGNORECASE,
+)
+
+
+class UCAgentConfigLoader(yaml.SafeLoader):
+    """Safe YAML loader with support for negated boolean scalars."""
+
+
+def _construct_negated_bool(loader, node):
+    scalar_value = loader.construct_scalar(node).strip()
+    if scalar_value.startswith('-'):
+        bool_value = scalar_value[1:]
+    else:
+        bool_value = re.sub(r"^not[ \t]+", "", scalar_value, count=1, flags=re.IGNORECASE)
+    return not SafeConstructor.bool_values[bool_value.lower()]
+
+
+UCAgentConfigLoader.add_implicit_resolver('!negated_bool', _NEGATED_BOOL_PATTERN, ['-', 'n', 'N'])
+UCAgentConfigLoader.add_constructor('!negated_bool', _construct_negated_bool)
 
 class Config:
     """Configuration class for UCAgent settings."""
@@ -283,18 +308,23 @@ def find_file_in_paths(filename, search_paths):
     return None
 
 
+def load_yaml_with_env_vars(file_path):
+    """Load YAML after environment-variable substitution.
+
+    Supports negated boolean scalars like ``not true`` and ``-false``.
+    """
+    with open(file_path, 'r', encoding='utf-8') as file:
+        content = file.read()
+        rendered_content = replace_bash_var(content, os.environ)
+        return yaml.load(rendered_content, Loader=UCAgentConfigLoader)
+
+
 def get_config(config_file=None, cfg_override=None, workspace=None):
     """
     Get the configuration for the agent.
     :param config_file: Path to the configuration file.
     :return: Configuration dictionary.
     """
-    def load_yaml_with_env_vars(file_path):
-        with open(file_path, 'r') as file:
-            content = file.read()
-            rendered_content = replace_bash_var(content, os.environ)
-            return yaml.safe_load(rendered_content)
-
     # ignore repeated loaded configs
     loaded_configs = []
 

--- a/ucagent/util/functions.py
+++ b/ucagent/util/functions.py
@@ -692,6 +692,8 @@ def render_template(template: str, kwargs) -> str:
     :param kwargs: Keyword arguments to be used in the template.
     :return: The rendered string.
     """
+    if not isinstance(template, str):
+        return template
     tvalue = template.strip()
     if (tvalue.count("{") == tvalue.count("}") == 1) and \
        (tvalue.startswith("{") and tvalue.endswith("}")):
@@ -1709,6 +1711,31 @@ def check_file_block(file_blocks, workspace, checker=None):
     return ret_map
 
 
+def tc_list_as_loc_blocks(func_list, target_tc_prefix="", ignore_tc_prefix=""):
+    func_file_blocks = {}
+    for tc in func_list:
+        tc_fname, (file_path, line_from, line_to) = parse_test_case_name(tc)
+        tc_name = tc_fname.split("::", 1)[-1]
+        if target_tc_prefix and not tc_name.startswith(target_tc_prefix):
+            continue
+        if ignore_tc_prefix and tc_name.startswith(ignore_tc_prefix):
+            continue
+        if file_path not in func_file_blocks:
+            func_file_blocks[file_path] = {}
+        func_file_blocks[file_path][tc] = [line_from, line_to]
+    return func_file_blocks
+
+
+def parse_test_case_name(tc):
+    # file.py:xx-yy::[ClassName::]test_func
+    tc_file, tc_name = tc.split("::", 1)
+    tc_rfile, line_range = tc_file.split(":")
+    tc_file = tc_rfile.split("/tests/", 1)[-1]
+    a, b = line_range.split("-", 1)
+    assert a.isdigit() and b.isdigit(), f"Invalid line range in test case '{tc}'."
+    return f"{tc_file}::{tc_name}", (tc_rfile, int(a), int(b))
+
+
 def description_mark_function_doc(
     func_list=[], workspace=None, func_RunTestCases=None, timeout_RunTestCases=0
 ):
@@ -1723,14 +1750,6 @@ def description_mark_function_doc(
         "If the test case is redundant, delete it. (See Guide_Doc/dut_test_case.md)"
     )
 
-    def parse_test_case_name(tc):
-        # file.py:xx-yy::[ClassName::]test_func
-        tc_file, tc_name = tc.split("::", 1)
-        tc_rfile, line_range = tc_file.split(":")
-        tc_file = tc_rfile.split("/tests/", 1)[-1]
-        a, b = line_range.split("-", 1)
-        assert a.isdigit() and b.isdigit(), f"Invalid line range in test case '{tc}'."
-        return f"{tc_file}::{tc_name}", (tc_rfile, int(a), int(b))
     if len(func_list) > 0:
         assert workspace is not None, "workspace must be provided if func_list is empty."
         func_file_blocks = {}
@@ -2489,3 +2508,32 @@ def find_most_similar_strings(a: Union[str, List[str]], b: List[str]) -> Union[i
 
 def get_workspace_skill_root(workspace):
     return get_abs_path_cwd_ucagent(workspace, "skills")
+
+
+def get_func_params_regex(source_code: str) -> list[str]:
+    """
+    Extract function parameter names from the source code of a Python function using regular expressions.
+    """
+    pattern = r'def\s+\w+\s*\(([^)]*)\)'
+    match = re.search(pattern, source_code)
+    if not match:
+        return []
+    params_str = match.group(1).strip()
+    if not params_str:
+        return []
+    params = []
+    current = ""
+    bracket_count = 0
+    for char in params_str:
+        if char == ',' and bracket_count == 0:
+            params.append(current.strip())
+            current = ""
+        else:
+            if char in '([{':
+                bracket_count += 1
+            elif char in ')]}':
+                bracket_count -= 1
+            current += char
+    if current:
+        params.append(current.strip())
+    return params

--- a/ucagent/verify_pdb.py
+++ b/ucagent/verify_pdb.py
@@ -3282,3 +3282,10 @@ class VerifyPDB(Pdb):
         except Exception as e:
             echo_y(e)
             echo_r("usage: sleep <seconds>")
+
+    def do_logo_and_version(self, arg):
+        """
+        Show the agent version and logo.
+        """
+        from .version import banner as logo
+        echo(logo)

--- a/ucagent/version.py
+++ b/ucagent/version.py
@@ -9,3 +9,12 @@ except ImportError:
 __author__ = "XS-MLVP"
 __email__ = "unitychip@bosc.ac.cn"
 __description__ = "UnityChip Verification Agent - AI-powered hardware verification tool"
+
+banner = f"""
+\u001b[34m   __  __   ______    ___                           __ \u001b[0m
+\u001b[34m  / / / /  / ____/   /   |   ____ _  ___    ____   / /_\u001b[0m
+\u001b[34m / / / /  / /       / /| |  / __ `/ / _ \\  / __ \\ / __/\u001b[0m
+\u001b[34m/ /_/ /  / /___    / ___ | / /_/ / /  __/ / / / // /_ \u001b[0m
+\u001b[34m\\____/   \\____/   /_/  |_| \\__, /  \\___/ /_/ /_/ \\__/\u001b[0m
+\u001b[34m                          /____/                       \u001b[0m \u001b[36mv{__version__}\u001b[0m
+"""


### PR DESCRIPTION
## Summary

  This PR adds an optional reference model workflow to the verification pipeline, controlled by `NEED_REF_MODEL`. When
  enabled, the agent now guides users through reference model implementation, fixture creation, reference-model-based API
  testing, and stricter test function argument validation.

  It also improves configuration loading by supporting negated boolean YAML scalars such as `not true` and `-false`, and
  centralizes the UCAgent logo/version banner so CLI and server paths share the same output.

  ## Changes

  ### Reference Model Workflow

  - Added reference model stages to the default Chinese verification workflow:
    - `reference_model_implementation`
    - `reference_model_fixture_imp`
  - Gated the reference model workflow with `NEED_REF_MODEL`.
  - Updated API, template, batch, and random test guidance to use `ref_model` when reference model support is enabled.
  - Added checks to enforce test function argument order when `NEED_REF_MODEL` is enabled:
    - API tests must use `env` as the first argument.
    - Reference-model-enabled tests must use `ref_model` as the second argument.
  - Added documentation for the required API test function argument order in `Guide_Doc/dut_test_case.md`.

  ### Checker and Utility Support

  - Extended `BaseUnityChipCheckerTestCase` with optional argument-pattern validation.
  - Reused the argument validation path in DUT API test checking.
  - Added utility helpers for parsing pytest test case locations and extracting function parameters.
  - Made `render_template()` safely return non-string values unchanged.

  ### Configuration Loading

  - Added `UCAgentConfigLoader`, a custom YAML SafeLoader that supports negated boolean scalars.
  - Exposed `load_yaml_with_env_vars()` as a module-level helper.
  - Added config loader tests for:
    - `not true`
    - `-false`
    - negated booleans inside lists
    - preserving plain strings such as `not enabled`
  - Updated `model_type` to allow environment override via `UC_MODEL_TYPE`.

  ### Logo and Version Banner

  - Moved the UCAgent ASCII logo/version banner into `ucagent/version.py`.
  - Updated the web terminal banner output to reuse the shared banner.
  - Added a `logo_and_version` command.
  - Added `logo_and_version` to CLI startup initialization commands.

  ## Testing

  - Added `tests/test_config_loader.py` for negated boolean YAML parsing.
  - Verified the latest staged diff with `git diff --check`.

  ## Notes

  The reference model flow remains optional and is controlled by `NEED_REF_MODEL`. Existing workflows should continue to run
  without the reference model stages unless that flag is enabled.