### PR TITLE
docker: ensure npm global CLIs are on PATH in image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,18 @@ RUN node --version && \
     python3 -m pip --version
 
 # Install Code Agent CLIs.
-RUN npm install -g @anthropic-ai/claude-code && claude --version
-RUN npm install -g @openai/codex && codex --version
-RUN npm install -g @kilocode/cli && kilo --version
-RUN npm install -g opencode-ai && opencode --version
+RUN npm install -g @anthropic-ai/claude-code @openai/codex @kilocode/cli opencode-ai
+
+# The base image installs Node via nvm under /usr/local/nvm and exports that
+# bin directory in PATH. Reassert it here so the CLI checks do not depend on
+# shell startup files.
+ENV PATH="/usr/local/nvm/versions/node/v20.12.2/bin:${PATH}"
+
+# Verify that the Code Agent CLIs are installed correctly.
+RUN claude --version && \
+    kilo --version && \
+    opencode --version && \
+    codex --version
 
 # Set working directory
 WORKDIR /workspace/UCAgent


### PR DESCRIPTION
## Summary

ensure npm global CLIs are on PATH in image build

## Changes
- [x] Code

## Testing
Describe how you tested the changes, including commands run or screenshots if relevant.

```
# examples:
docker build -f Dockerfile -t ucagent:latest
```

## Checklist
- [x] I read and followed `CONTRIBUTING.md`.
- [x] I ran all relevant tests and they pass locally.
- [x] I updated documentation/examples if behavior changed.
- [x] I agree that this contribution will be released under the project's open-source license (see `LICENSE`).
- [x] I agree to follow the repository's Code of Conduct.
