### PR TITLE
fix: package shared formal lib into generated workspaces

### DIFF
--- a/ucagent/lang/zh/skills/formal/lib/SKILL.md
+++ b/ucagent/lang/zh/skills/formal/lib/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: formal-lib
+description: Internal support skill for formal verification workspaces. This folder carries shared Python helpers and templates used by other formal skills and is not intended for direct user invocation.
+---
+
+# Formal Shared Library
+
+This is an internal packaging skill.
+
+It exists so the workspace skill copy step includes this directory and makes the shared helpers under `formal/lib/` available to the other formal skills.
+
+Do not select this skill for standalone task execution unless you are specifically maintaining the shared formal helper library.


### PR DESCRIPTION
## Summary
- Fixes formal workspace initialization so the shared `ucagent/lang/zh/skills/formal/lib/` directory is copied into the generated workspace skill tree.
- Without this change, the formal skills that depend on shared helpers and templates under `formal/lib/` can be packaged incompletely because the existing copy logic only includes directories recognized as skills.
- This PR keeps the existing copy behavior unchanged and uses a minimal packaging marker instead of changing the copy pipeline itself.

## Changes
- [ ] Code
- [x] Documentation
- [ ] Tests
- [x] Examples / Tooling

- Add `ucagent/lang/zh/skills/formal/lib/SKILL.md`.
- Mark `formal/lib/` as an internal packaging skill so the existing skill copy step includes the shared library directory in workspace output.
- Keep the directory documented as internal-only and not intended for direct standalone invocation.

## Testing
Verified the committed change scope and resulting behavior by inspecting the packaging input and commit contents.

```bash
make formal_mcp_Adder
ls examples/Formal/output/workspace_Adder/.ucagent/skills/formal/
```

## Checklist
- [ ] I read and followed `CONTRIBUTING.md`.
- [ ] I ran all relevant tests and they pass locally.
- [x] I updated documentation/examples if behavior changed.
- [ ] I agree that this contribution will be released under the project's open-source license (see `LICENSE`).
- [ ] I agree to follow the repository's Code of Conduct.